### PR TITLE
Log killer process name on protection

### DIFF
--- a/Plugins/Filter/ProtectProcess.c
+++ b/Plugins/Filter/ProtectProcess.c
@@ -224,9 +224,10 @@ static OB_PREOP_CALLBACK_STATUS ObPreOperation(PVOID RegistrationContext, POB_PR
                     Info->Parameters->DuplicateHandleInformation.DesiredAccess;
                 if (da & PROCESS_TERMINATE) {
                     CHAR buf[128] = { 0 };
+                    PCSTR img = PsGetProcessImageFileName(PsGetCurrentProcess());
                     RtlStringCchPrintfA(buf, RTL_NUMBER_OF(buf),
-                        "PROC_KILL_ATTEMPT | %u | %u", (ULONG)(ULONG_PTR)cur,
-                        (ULONG)(ULONG_PTR)tpid);
+                        "PROC_KILL_ATTEMPT | %u | %u | %s", (ULONG)(ULONG_PTR)cur,
+                        (ULONG)(ULONG_PTR)tpid, img ? img : "");
                     SendPipeLog(buf, strlen(buf));
                     PsSuspendProcess(PsGetCurrentProcess());
                     RestartProtectedProcess();


### PR DESCRIPTION
## Summary
- include the image name of the process attempting to terminate a protected process
- show the attacker process name in pipe server messages
- register the main program's PID with the driver so kill attempts are attributed correctly

## Testing
- `python -m py_compile PYAS.py`


------
https://chatgpt.com/codex/tasks/task_e_68b136611f5c832c987c33e06d076cd2